### PR TITLE
fix: small tweaks for responsive styles

### DIFF
--- a/src/app/components/article/article2/article2.component.html
+++ b/src/app/components/article/article2/article2.component.html
@@ -26,7 +26,7 @@
 	</article>
 	<div class="">
 		<div
-			class="flex flex-wrap py-6 space-x-2 border-t border-dashed"
+			class="flex flex-wrap py-6 gap-2 border-t border-dashed"
 			[ngClass]="['border' + plainInv]"
 		>
 			<a

--- a/src/app/components/pricing/pricing5/pricing5.component.html
+++ b/src/app/components/pricing/pricing5/pricing5.component.html
@@ -9,7 +9,7 @@
 		<div class="flex flex-wrap items-stretch -mx-4">
 			<div class="flex w-full mb-8 sm:px-4 md:w-1/2 lg:w-1/3 lg:mb-0">
 				<div
-					class="flex flex-col p-6 space-y-6 rounded shadow sm:p-8"
+					class="flex flex-grow flex-col p-6 space-y-6 rounded shadow sm:p-8"
 					[ngClass]="['bg' + contrast]"
 				>
 					<div class="space-y-2">
@@ -80,7 +80,7 @@
 			</div>
 			<div class="flex w-full mb-8 sm:px-4 md:w-1/2 lg:w-1/3 lg:mb-0">
 				<div
-					class="flex flex-col p-6 space-y-6 rounded shadow sm:p-8"
+					class="flex flex-grow flex-col p-6 space-y-6 rounded shadow sm:p-8"
 					[ngClass]="['bg' + primary, 'text' + contrast]"
 				>
 					<div class="space-y-2">
@@ -164,8 +164,8 @@
 					</a>
 				</div>
 			</div>
-			<div class="w-full mb-8 sm:px-4 md:w-1/2 lg:w-1/3 lg:mb-0">
-				<div class="p-6 space-y-6 rounded shadow sm:p-8" [ngClass]="['bg' + contrast]">
+			<div class="flex w-full mb-8 sm:px-4 md:w-1/2 lg:w-1/3 lg:mb-0">
+				<div class="flex flex-grow flex-col p-6 space-y-6 rounded shadow sm:p-8" [ngClass]="['bg' + contrast]">
 					<div class="space-y-2">
 						<h4 class="text-2xl font-bold">Team</h4>
 						<span class="text-6xl font-bold">


### PR DESCRIPTION
Hi! Nice to meet you, I personally love the look of Mamba UI and actually noticed 2 small issues on mobile view, so I decided to contribute to the project:

# Bug 1 - Article 2
Tags with wrong spacing when wrapped, fixed using gap instead of space:

How it looks:
<img width="334" alt="Screenshot 2023-10-01 at 21 15 32" src="https://github.com/Microwawe/mamba-ui/assets/9610219/f5ccf178-e18d-40bd-b730-f7090efdca18">

After fix:
<img width="334" alt="Screenshot 2023-10-01 at 21 15 55" src="https://github.com/Microwawe/mamba-ui/assets/9610219/3cf974ef-9f5d-4405-91e6-3a53405dd668">

# Bug 2 - Princing 5
Princing types having different wrapping behaviour in mobile view, the third item it taking full width but the first 2 don't

How it looks:
<img width="521" alt="Screenshot 2023-10-01 at 21 18 29" src="https://github.com/Microwawe/mamba-ui/assets/9610219/0740b6d1-30b2-44ba-bdd2-0791f9be1058">

After fix (they all take the full width):
<img width="521" alt="Screenshot 2023-10-01 at 21 19 59" src="https://github.com/Microwawe/mamba-ui/assets/9610219/7b20074e-9e26-49ff-910f-b9baae4843f8">

Thanks in advance for your review! Hope you like it and my congrats for the tailwind kit you created :)